### PR TITLE
Migrate from store watchers to vm watchers

### DIFF
--- a/client/src/components/FilteredMap.vue
+++ b/client/src/components/FilteredMap.vue
@@ -35,7 +35,7 @@ export default {
     this.mmap = new ManagedMap()
 
     // watch if the viewport is resized and resize the map
-    this.$store.watch(
+    this.$watch(
       (state) => {
         return this.$store.state.resizeMap
       },
@@ -50,7 +50,7 @@ export default {
     // const f = this.redrawTracks
     const unboundRedrawTracks = this.redrawTracks
     const boundRedrawTracks = unboundRedrawTracks.bind(this)
-    this.$store.watch(
+    this.$watch(
       (state) => {
         return this.$store.state.redrawTracksOnMap
       },


### PR DESCRIPTION
because the actions we perform on the watch
is only relevant for the
rendered component and not independently for the
store